### PR TITLE
[#145998989] ubi: Add support for it

### DIFF
--- a/fs/ubifs/super.c
+++ b/fs/ubifs/super.c
@@ -2135,6 +2135,7 @@ const struct super_operations ubifs_super_operations = {
  * o ubiY      - mount UBI device number 0, volume Y;
  * o ubiX:NAME - mount UBI device X, volume with name NAME;
  * o ubi:NAME  - mount UBI device 0, volume with name NAME.
+ * o ????      - mount UBI device 0, volume with name "rootfs".
  *
  * Alternative '!' separator may be used instead of ':' (because some shells
  * like busybox may interpret ':' as an NFS host name separator). This function
@@ -2158,7 +2159,7 @@ static struct ubi_volume_desc *open_ubi(const char *name, int mode)
 
 	/* Try the "nodev" method */
 	if (name[0] != 'u' || name[1] != 'b' || name[2] != 'i')
-		return ERR_PTR(-EINVAL);
+		return ubi_open_volume_nm(0, "rootfs", mode);
 
 	/* ubi:NAME method */
 	if ((name[3] == ':' || name[3] == '!') && name[4] != '\0')

--- a/include/configs/at91sam9m10g45ek.h
+++ b/include/configs/at91sam9m10g45ek.h
@@ -186,11 +186,29 @@
 #define CONFIG_CMDLINE_EDITING
 #define CONFIG_AUTO_COMPLETE
 #define CONFIG_SYS_HUSH_PARSER
+#define CONFIG_CMD_UBI
+#define CONFIG_CMD_UBIFS
+#define CONFIG_RBTREE
+#define CONFIG_MTD_DEVICE
+#define CONFIG_MTD_PARTITIONS
+#define CONFIG_CMD_MTDPARTS
+#define CONFIG_LZO
+#define MTDIDS_DEFAULT			"nand0=atmel_nand"
+#define MTDPARTS_DEFAULT		"mtdparts=atmel_nand:128K(bootstrap)ro,256K(u-boot-env),640K(u-boot)ro,6M(kernel)ro,-(rootfs)"
+#define CONFIG_EXTRA_ENV_SETTINGS	\
+	"mtdids="MTDIDS_DEFAULT"\0"	\
+	"mtdparts="MTDPARTS_DEFAULT"\0"
+#define CONFIG_BOOTCOMMAND		\
+	"ubi part rootfs && "		\
+	"ubifsmount ubi0 && " \
+	"ubifsload 70008000 /boot/uImage && " \
+	"setenv bootargs panic=1 quiet ${mtdparts} root=ubi0 rw ubi.mtd=4,512 rootfstype=ubifs && " \
+	"bootm 70008000"
 
 /*
  * Size of malloc() pool
  */
-#define CONFIG_SYS_MALLOC_LEN		ROUND(3 * CONFIG_ENV_SIZE + 128*1024, 0x1000)
+#define CONFIG_SYS_MALLOC_LEN		(8 * 1024 * 1024)	/* 8 MiB for malloc() */
 
 /* Defines for SPL */
 #define CONFIG_SPL_FRAMEWORK


### PR DESCRIPTION
Some stuff to do later:
- load kernel from rootfs instead of separate partition
- remove kernel partition
- move rootfs partition (claim the space left by removing the kernel partition)

Backwards compatibility issue:
- name of the ubifs volume: ubi0 or ubi0:rootfs where oe-classic used nedap9g45-rootfs
