### PR TITLE
[#147509545] Turn on periodic watchdog resets

### DIFF
--- a/include/configs/at91sam9m10g45ek.h
+++ b/include/configs/at91sam9m10g45ek.h
@@ -283,4 +283,8 @@
 #define CONFIG_SYS_FPGA_DOUT_PIN  AT91_PIO_PORTC, 16
 #define CONFIG_FPGA_BAUDRATE      115200
 
+/* hardware watchdog config */
+#define CONFIG_AT91SAM9_WATCHDOG  1
+#define CONFIG_HW_WATCHDOG        1
+
 #endif


### PR DESCRIPTION
To keep the system from rebooting during the bootloader, the watchdog
has to be reset periodically. This functionality is built in with
u-boot, but had to be turned on. Also, with the OE-classic
implementation, a patch was done because the nand operations possibly
blocked for too long causing the unit to reset. It was confirmed that
this problem has been fixed with the current version of U-boot.