### PR TITLE
[#149728359] Fix u-boot fatls return value

### DIFF
--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -1183,6 +1183,7 @@ rootdir_done:
 				     isdir ? 0 : dols) == NULL) {
 			if (dols && !isdir)
 				*size = 0;
+			ret = 0;
 			goto exit;
 		}
 


### PR DESCRIPTION
USB reflasing was broken because fatls returned a non-zero integer even
though the operation succeeded. It was fixed by setting the return
value, like it is supposed to.