### PR TITLE
[codex] Backport U-Boot CodeQL maintenance fixes

### DIFF
--- a/board/freescale/b4860qds/spl.c
+++ b/board/freescale/b4860qds/spl.c
@@ -81,7 +81,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t102xqds/spl.c
+++ b/board/freescale/t102xqds/spl.c
@@ -110,7 +110,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t102xrdb/spl.c
+++ b/board/freescale/t102xrdb/spl.c
@@ -97,7 +97,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t104xrdb/spl.c
+++ b/board/freescale/t104xrdb/spl.c
@@ -88,7 +88,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t208xqds/spl.c
+++ b/board/freescale/t208xqds/spl.c
@@ -96,7 +96,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t208xrdb/spl.c
+++ b/board/freescale/t208xrdb/spl.c
@@ -66,7 +66,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t4qds/spl.c
+++ b/board/freescale/t4qds/spl.c
@@ -106,7 +106,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/board/freescale/t4rdb/spl.c
+++ b/board/freescale/t4rdb/spl.c
@@ -70,7 +70,7 @@ void board_init_r(gd_t *gd, ulong dest_addr)
 {
 	bd_t *bd;
 
-	bd = (bd_t *)(gd + sizeof(gd_t));
+	bd = (bd_t *)(gd + 1);
 	memset(bd, 0, sizeof(bd_t));
 	gd->bd = bd;
 	bd->bi_memstart = CONFIG_SYS_INIT_L3_ADDR;

--- a/cmd/nand.c
+++ b/cmd/nand.c
@@ -359,7 +359,7 @@ static void adjust_size_for_badblocks(loff_t *size, loff_t offset, int dev)
 	}
 	/* adjust size if any bad blocks found */
 	if (badblocks) {
-		*size -= badblocks * nand->erasesize;
+		*size -= (loff_t)badblocks * nand->erasesize;
 		printf("size adjusted to 0x%llx (%d bad blocks)\n",
 		       (unsigned long long)*size, badblocks);
 	}

--- a/drivers/mtd/mtdpart.c
+++ b/drivers/mtd/mtdpart.c
@@ -482,7 +482,9 @@ static struct mtd_part *allocate_partition(struct mtd_info *master,
 		slave->offset = cur_offset;
 		if (mtd_mod_by_eb(cur_offset, master) != 0) {
 			/* Round up to next erasesize */
-			slave->offset = (mtd_div_by_eb(cur_offset, master) + 1) * master->erasesize;
+			slave->offset =
+				(loff_t)(mtd_div_by_eb(cur_offset, master) + 1) *
+				master->erasesize;
 			debug("Moving partition %d: "
 			       "0x%012llx -> 0x%012llx\n", partno,
 			       (unsigned long long)cur_offset, (unsigned long long)slave->offset);

--- a/drivers/mtd/ubi/fastmap.c
+++ b/drivers/mtd/ubi/fastmap.c
@@ -931,7 +931,7 @@ int ubi_scan_fastmap(struct ubi_device *ubi, struct ubi_attach_info *ai,
 		goto free_fm_sb;
 	}
 
-	fm_size = ubi->leb_size * used_blocks;
+	fm_size = (size_t)ubi->leb_size * used_blocks;
 	if (fm_size != ubi->fm_size) {
 		ubi_err(ubi, "bad fastmap size: %zi, expected: %zi",
 			fm_size, ubi->fm_size);

--- a/drivers/net/bcm-sf2-eth-gmac.c
+++ b/drivers/net/bcm-sf2-eth-gmac.c
@@ -187,8 +187,7 @@ static int dma_tx_init(struct eth_dma *dma)
 	descp = dma->tx_desc_aligned;
 	bufp = dma->tx_buf;
 	flush_dcache_range((unsigned long)descp,
-			   (unsigned long)(descp +
-					   sizeof(dma64dd_t) * TX_BUF_NUM));
+			   (unsigned long)(descp + TX_BUF_NUM));
 	flush_dcache_range((unsigned long)(bufp),
 			   (unsigned long)(bufp + TX_BUF_SIZE * TX_BUF_NUM));
 
@@ -240,8 +239,7 @@ static int dma_rx_init(struct eth_dma *dma)
 	bufp = dma->rx_buf;
 	/* flush descriptor and buffer */
 	flush_dcache_range((unsigned long)descp,
-			   (unsigned long)(descp +
-					   sizeof(dma64dd_t) * RX_BUF_NUM));
+			   (unsigned long)(descp + RX_BUF_NUM));
 	flush_dcache_range((unsigned long)(bufp),
 			   (unsigned long)(bufp + RX_BUF_SIZE * RX_BUF_NUM));
 
@@ -349,7 +347,7 @@ int gmac_tx_packet(struct eth_dma *dma, void *packet, int length)
 
 	/* flush descriptor and buffer */
 	flush_dcache_range((unsigned long)descp,
-			   (unsigned long)(descp + sizeof(dma64dd_t)));
+			   (unsigned long)(descp + 1));
 	flush_dcache_range((unsigned long)bufp,
 			   (unsigned long)(bufp + TX_BUF_SIZE));
 
@@ -431,7 +429,7 @@ int gmac_check_rx_done(struct eth_dma *dma, uint8_t *buf)
 	descp = (dma64dd_t *)(dma->rx_desc_aligned) + index;
 	/* flush descriptor and buffer */
 	flush_dcache_range((unsigned long)descp,
-			   (unsigned long)(descp + sizeof(dma64dd_t)));
+			   (unsigned long)(descp + 1));
 	flush_dcache_range((unsigned long)bufp,
 			   (unsigned long)(bufp + RX_BUF_SIZE));
 
@@ -462,7 +460,7 @@ int gmac_check_rx_done(struct eth_dma *dma, uint8_t *buf)
 	descp->addrhigh = 0;
 	/* flush descriptor */
 	flush_dcache_range((unsigned long)descp,
-			   (unsigned long)(descp + sizeof(dma64dd_t)));
+			   (unsigned long)(descp + 1));
 
 	/* set the lastdscr for the rx ring */
 	writel(((uint32_t)descp) & D64_XP_LD_MASK, GMAC0_DMA_RX_PTR_ADDR);

--- a/drivers/pinctrl/uniphier/pinctrl-uniphier.h
+++ b/drivers/pinctrl/uniphier/pinctrl-uniphier.h
@@ -84,10 +84,10 @@ struct uniphier_pinctrl_socdata {
 	{								\
 		.name = #grp,						\
 		.pins = grp##_pins,					\
-		.num_pins = ARRAY_SIZE(grp##_pins),			\
-		.muxvals = grp##_muxvals +				\
+		.num_pins = ARRAY_SIZE(grp##_pins) +			\
 			BUILD_BUG_ON_ZERO(ARRAY_SIZE(grp##_pins) !=	\
 					  ARRAY_SIZE(grp##_muxvals)),	\
+		.muxvals = grp##_muxvals,				\
 	}
 
 /**

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -876,6 +876,7 @@ int do_fat_read_at(const char *filename, loff_t pos, void *buffer,
 	}
 
 	mydata->fatbufnum = -1;
+	mydata->fat_dirty = 0;
 	mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
 	if (mydata->fatbuf == NULL) {
 		debug("Error: allocating memory\n");

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -202,6 +202,7 @@ static __u32 get_fatent(fsdata *mydata, __u32 entry)
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
 
+		/* Cap length if fatlength is not a multiple of FATBUFBLOCKS */
 		if (startblock + getsize > fatlength)
 			getsize = fatlength - startblock;
 

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -300,6 +300,12 @@ get_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer, unsigned long size)
 	return 0;
 }
 
+static unsigned long fat_cluster_size(const fsdata *mydata)
+{
+	return (unsigned long)mydata->clust_size *
+	       (unsigned long)mydata->sect_size;
+}
+
 /*
  * Read at most 'maxsize' bytes from 'pos' in the file associated with 'dentptr'
  * into 'buffer'.
@@ -312,7 +318,7 @@ static int get_contents(fsdata *mydata, dir_entry *dentptr, loff_t pos,
 			__u8 *buffer, loff_t maxsize, loff_t *gotsize)
 {
 	loff_t filesize = FAT2CPU32(dentptr->size);
-	unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
+	unsigned long bytesperclust = fat_cluster_size(mydata);
 	__u32 curclust = START(dentptr);
 	__u32 endclust, newclust;
 	loff_t actsize;
@@ -494,7 +500,7 @@ get_vfatname(fsdata *mydata, int curclust, __u8 *cluster,
 		}
 
 		if (get_cluster(mydata, curclust, get_contents_vfatname_block,
-				mydata->clust_size * mydata->sect_size) != 0) {
+				fat_cluster_size(mydata)) != 0) {
 			debug("Error: reading directory block\n");
 			return -1;
 		}
@@ -576,7 +582,7 @@ static dir_entry *get_dentfromdir(fsdata *mydata, int startsect,
 		int i;
 
 		if (get_cluster(mydata, curclust, get_dentfromdir_block,
-				mydata->clust_size * mydata->sect_size) != 0) {
+				fat_cluster_size(mydata)) != 0) {
 			debug("Error: reading directory block\n");
 			return NULL;
 		}

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -169,7 +169,7 @@ static void get_name(dir_entry *dirent, char *s_name)
 static __u32 get_fatent(fsdata *mydata, __u32 entry)
 {
 	__u32 bufnum;
-	__u32 off16, offset;
+	__u32 offset, off8;
 	__u32 ret = 0x00;
 
 	switch (mydata->fatsize) {
@@ -223,8 +223,9 @@ static __u32 get_fatent(fsdata *mydata, __u32 entry)
 		ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
 		break;
 	case 12:
-		off16 = (offset * 3) / 2;
-		ret = FAT2CPU16(*(__u16 *)(mydata->fatbuf + off16));
+		off8 = (offset * 3) / 2;
+		/* fatbut + off8 may be unaligned, read in byte granularity */
+		ret = mydata->fatbuf[off8] + (mydata->fatbuf[off8 + 1] << 8);
 
 		if (offset & 0x1)
 			ret >>= 4;

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -171,7 +171,6 @@ static __u32 get_fatent(fsdata *mydata, __u32 entry)
 	__u32 bufnum;
 	__u32 off16, offset;
 	__u32 ret = 0x00;
-	__u16 val1, val2;
 
 	switch (mydata->fatsize) {
 	case 32:
@@ -224,35 +223,12 @@ static __u32 get_fatent(fsdata *mydata, __u32 entry)
 		ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
 		break;
 	case 12:
-		off16 = (offset * 3) / 4;
+		off16 = (offset * 3) / 2;
+		ret = FAT2CPU16(*(__u16 *)(mydata->fatbuf + off16));
 
-		switch (offset & 0x3) {
-		case 0:
-			ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
-			ret &= 0xfff;
-			break;
-		case 1:
-			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			val1 &= 0xf000;
-			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-			val2 &= 0x00ff;
-			ret = (val2 << 4) | (val1 >> 12);
-			break;
-		case 2:
-			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			val1 &= 0xff00;
-			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-			val2 &= 0x000f;
-			ret = (val2 << 8) | (val1 >> 8);
-			break;
-		case 3:
-			ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			ret = (ret & 0xfff0) >> 4;
-			break;
-		default:
-			break;
-		}
-		break;
+		if (offset & 0x1)
+			ret >>= 4;
+		ret &= 0xfff;
 	}
 	debug("FAT%d: ret: %08x, offset: %04x\n",
 	       mydata->fatsize, ret, offset);

--- a/fs/fat/fat_write.c
+++ b/fs/fat/fat_write.c
@@ -105,12 +105,18 @@ static __u8 num_of_fats;
 /*
  * Write fat buffer into block device
  */
-static int flush_fat_buffer(fsdata *mydata)
+static int flush_dirty_fat_buffer(fsdata *mydata)
 {
 	int getsize = FATBUFBLOCKS;
 	__u32 fatlength = mydata->fatlength;
 	__u8 *bufptr = mydata->fatbuf;
 	__u32 startblock = mydata->fatbufnum * FATBUFBLOCKS;
+
+	debug("debug: evicting %d, dirty: %d\n", mydata->fatbufnum,
+	      (int)mydata->fat_dirty);
+
+	if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
+		return 0;
 
 	startblock += mydata->fat_sect;
 
@@ -131,6 +137,7 @@ static int flush_fat_buffer(fsdata *mydata)
 			return -1;
 		}
 	}
+	mydata->fat_dirty = 0;
 
 	return 0;
 }
@@ -188,10 +195,8 @@ static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
 		startblock += mydata->fat_sect;	/* Offset from start of disk */
 
 		/* Write back the fatbuf to the disk */
-		if (mydata->fatbufnum != -1) {
-			if (flush_fat_buffer(mydata) < 0)
-				return -1;
-		}
+		if (flush_dirty_fat_buffer(mydata) < 0)
+			return -1;
 
 		if (disk_read(startblock, getsize, bufptr) < 0) {
 			debug("Error reading FAT blocks\n");
@@ -498,10 +503,8 @@ static int set_fatent_value(fsdata *mydata, __u32 entry, __u32 entry_value)
 		if (getsize > fatlength)
 			getsize = fatlength;
 
-		if (mydata->fatbufnum != -1) {
-			if (flush_fat_buffer(mydata) < 0)
-				return -1;
-		}
+		if (flush_dirty_fat_buffer(mydata) < 0)
+			return -1;
 
 		if (disk_read(startblock, getsize, bufptr) < 0) {
 			debug("Error reading FAT blocks\n");
@@ -509,6 +512,9 @@ static int set_fatent_value(fsdata *mydata, __u32 entry, __u32 entry_value)
 		}
 		mydata->fatbufnum = bufnum;
 	}
+
+	/* Mark as dirty */
+	mydata->fat_dirty = 1;
 
 	/* Set the actual entry */
 	switch (mydata->fatsize) {
@@ -649,7 +655,7 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
 
 	dir_curclust = dir_newclust;
 
-	if (flush_fat_buffer(mydata) < 0)
+	if (flush_dirty_fat_buffer(mydata) < 0)
 		return;
 
 	memset(get_dentfromdir_block, 0x00,
@@ -679,7 +685,7 @@ static int clear_fatent(fsdata *mydata, __u32 entry)
 	}
 
 	/* Flush fat buffer */
-	if (flush_fat_buffer(mydata) < 0)
+	if (flush_dirty_fat_buffer(mydata) < 0)
 		return -1;
 
 	return 0;
@@ -1015,6 +1021,7 @@ static int do_fat_write(const char *filename, void *buffer, loff_t size,
 	}
 
 	mydata->fatbufnum = -1;
+	mydata->fat_dirty = 0;
 	mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
 	if (mydata->fatbuf == NULL) {
 		debug("Error: allocating memory\n");
@@ -1115,7 +1122,7 @@ static int do_fat_write(const char *filename, void *buffer, loff_t size,
 	debug("attempt to write 0x%llx bytes\n", *actwrite);
 
 	/* Flush fat buffer */
-	ret = flush_fat_buffer(mydata);
+	ret = flush_dirty_fat_buffer(mydata);
 	if (ret) {
 		printf("Error: flush fat buffer\n");
 		goto exit;

--- a/fs/fat/fat_write.c
+++ b/fs/fat/fat_write.c
@@ -118,10 +118,11 @@ static int flush_dirty_fat_buffer(fsdata *mydata)
 	if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
 		return 0;
 
-	startblock += mydata->fat_sect;
+	/* Cap length if fatlength is not a multiple of FATBUFBLOCKS */
+	if (startblock + getsize > fatlength)
+		getsize = fatlength - startblock;
 
-	if (getsize > fatlength)
-		getsize = fatlength;
+	startblock += mydata->fat_sect;
 
 	/* Write FAT buf */
 	if (disk_write(startblock, getsize, bufptr) < 0) {
@@ -188,8 +189,9 @@ static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
 
-		if (getsize > fatlength)
-			getsize = fatlength;
+		/* Cap length if fatlength is not a multiple of FATBUFBLOCKS */
+		if (startblock + getsize > fatlength)
+			getsize = fatlength - startblock;
 
 		fatlength *= mydata->sect_size;	/* We want it in bytes now */
 		startblock += mydata->fat_sect;	/* Offset from start of disk */
@@ -497,14 +499,14 @@ static int set_fatent_value(fsdata *mydata, __u32 entry, __u32 entry_value)
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
 
-		fatlength *= mydata->sect_size;
-		startblock += mydata->fat_sect;
-
-		if (getsize > fatlength)
-			getsize = fatlength;
+		/* Cap length if fatlength is not a multiple of FATBUFBLOCKS */
+		if (startblock + getsize > fatlength)
+			getsize = fatlength - startblock;
 
 		if (flush_dirty_fat_buffer(mydata) < 0)
 			return -1;
+
+		startblock += mydata->fat_sect;
 
 		if (disk_read(startblock, getsize, bufptr) < 0) {
 			debug("Error reading FAT blocks\n");

--- a/fs/fat/fat_write.c
+++ b/fs/fat/fat_write.c
@@ -420,7 +420,7 @@ get_long_file_name(fsdata *mydata, int curclust, __u8 *cluster,
 		dir_curclust = curclust;
 
 		if (get_cluster(mydata, curclust, get_contents_vfatname_block,
-				mydata->clust_size * mydata->sect_size) != 0) {
+				fat_cluster_size(mydata)) != 0) {
 			debug("Error: reading directory block\n");
 			return -1;
 		}
@@ -463,7 +463,7 @@ get_long_file_name(fsdata *mydata, int curclust, __u8 *cluster,
 
 	if (slotptr2) {
 		memcpy(get_dentfromdir_block, get_contents_vfatname_block,
-			mydata->clust_size * mydata->sect_size);
+			fat_cluster_size(mydata));
 		cur_position = (__u8 *)realdent - get_contents_vfatname_block;
 		*retdent = (dir_entry *) &get_dentfromdir_block[cur_position];
 	}
@@ -644,7 +644,7 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
 
 	if (set_cluster(mydata, dir_curclust,
 		    get_dentfromdir_block,
-		    mydata->clust_size * mydata->sect_size) != 0) {
+		    fat_cluster_size(mydata)) != 0) {
 		printf("error: wrinting directory entry\n");
 		return;
 	}
@@ -661,7 +661,7 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
 		return;
 
 	memset(get_dentfromdir_block, 0x00,
-		mydata->clust_size * mydata->sect_size);
+		fat_cluster_size(mydata));
 
 	*dentptr = (dir_entry *) get_dentfromdir_block;
 }
@@ -704,7 +704,7 @@ set_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
 	      loff_t maxsize, loff_t *gotsize)
 {
 	loff_t filesize = FAT2CPU32(dentptr->size);
-	unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
+	unsigned long bytesperclust = fat_cluster_size(mydata);
 	__u32 curclust = START(dentptr);
 	__u32 endclust = 0, newclust = 0;
 	loff_t actsize;
@@ -840,7 +840,7 @@ static int is_next_clust(fsdata *mydata, dir_entry *dentptr)
 
 	cur_position = (__u8 *)dentptr - get_dentfromdir_block;
 
-	if (cur_position >= mydata->clust_size * mydata->sect_size)
+	if (cur_position >= fat_cluster_size(mydata))
 		return 1;
 	else
 		return 0;
@@ -865,7 +865,7 @@ static dir_entry *find_directory_entry(fsdata *mydata, int startsect,
 		int i;
 
 		if (get_cluster(mydata, curclust, get_dentfromdir_block,
-			    mydata->clust_size * mydata->sect_size) != 0) {
+			    fat_cluster_size(mydata)) != 0) {
 			printf("Error: reading directory block\n");
 			return NULL;
 		}
@@ -1132,7 +1132,7 @@ static int do_fat_write(const char *filename, void *buffer, loff_t size,
 
 	/* Write directory table to device */
 	ret = set_cluster(mydata, dir_curclust, get_dentfromdir_block,
-			mydata->clust_size * mydata->sect_size);
+			fat_cluster_size(mydata));
 	if (ret)
 		printf("Error: writing directory entry\n");
 

--- a/fs/ubifs/budget.c
+++ b/fs/ubifs/budget.c
@@ -250,7 +250,7 @@ long long ubifs_calc_available(const struct ubifs_info *c, int min_idx_lebs)
 	 */
 	if (c->lst.idx_lebs > min_idx_lebs) {
 		subtract_lebs = c->lst.idx_lebs - min_idx_lebs;
-		available -= subtract_lebs * c->dark_wm;
+		available -= (long long)subtract_lebs * c->dark_wm;
 	}
 
 	/* The calculations are rough and may end up with a negative number */
@@ -700,7 +700,7 @@ long long ubifs_get_free_space_nolock(struct ubifs_info *c)
 	lebs = c->lst.empty_lebs + c->freeable_cnt + c->idx_gc_cnt -
 	       c->lst.taken_empty_lebs;
 	lebs -= rsvd_idx_lebs;
-	available += lebs * (c->dark_wm - c->leb_overhead);
+	available += (long long)lebs * (c->dark_wm - c->leb_overhead);
 
 	if (available > outstanding)
 		free = ubifs_reported_space(c, available - outstanding);

--- a/fs/ubifs/ubifs.c
+++ b/fs/ubifs/ubifs.c
@@ -496,7 +496,7 @@ static unsigned long ubifs_findfile(struct super_block *sb, char *filename)
 	 * Handle root-direcoty ('/')
 	 */
 	inum = root_inum;
-	if (!name || *name == '\0')
+	if (*name == '\0')
 		return inum;
 
 	for (;;) {

--- a/include/fat.h
+++ b/include/fat.h
@@ -169,6 +169,7 @@ typedef struct {
 	int	fatsize;	/* Size of FAT in bits */
 	__u32	fatlength;	/* Length of FAT in sectors */
 	__u16	fat_sect;	/* Starting sector of the FAT */
+	__u8	fat_dirty;      /* Set if fatbuf has been modified */
 	__u32	rootdir_sect;	/* Start sector of root directory */
 	__u16	sect_size;	/* Size of sectors in bytes */
 	__u16	clust_size;	/* Size of clusters in sectors */

--- a/lib/display_options.c
+++ b/lib/display_options.c
@@ -174,7 +174,7 @@ int print_buffer(ulong addr, const void *data, uint width, uint count,
 		printf("    %s\n", lb.uc);
 
 		/* update references */
-		addr += thislinelen * width;
+		addr += (ulong)thislinelen * width;
 		count -= thislinelen;
 
 		if (ctrlc())

--- a/lib/gzip.c
+++ b/lib/gzip.c
@@ -95,9 +95,9 @@ int zzip(void *dst, unsigned long *lenp, unsigned char *src,
 				goto bail;
 			}
 			if (!func) {
-				dst += (left_len - s.avail_out);
-				*lenp -= (left_len - s.avail_out);
-			} else if (left_len - s.avail_out > 0) {
+				dst += left_len - s.avail_out;
+				*lenp -= left_len - s.avail_out;
+			} else if (left_len > s.avail_out) {
 				r = func((unsigned long)dst,
 					left_len - s.avail_out);
 				if (r < 0)

--- a/lib/libfdt/Makefile
+++ b/lib/libfdt/Makefile
@@ -5,5 +5,13 @@
 # SPDX-License-Identifier:	GPL-2.0+
 #
 
-obj-y += fdt.o fdt_ro.o fdt_rw.o fdt_strerror.o fdt_sw.o fdt_wip.o \
-	fdt_empty_tree.o fdt_addresses.o fdt_region.o
+obj-y += \
+	fdt.o \
+	fdt_ro.o \
+	fdt_rw.o \
+	fdt_strerror.o \
+	fdt_sw.o \
+	fdt_wip.o \
+	fdt_empty_tree.o \
+	fdt_addresses.o \
+	fdt_region.o

--- a/lib/libfdt/README
+++ b/lib/libfdt/README
@@ -1,5 +1,5 @@
 The libfdt functionality was written by David Gibson.  The original
-source came from the git repository:
+source came from the Git repository:
 
 URL:		git://ozlabs.org/home/dgibson/git/libfdt.git
 
@@ -11,13 +11,15 @@ commit		857f54e79f74429af20c2b5ecc00ee98af6a3b8b
 tree		2f648f0f88225a51ded452968d28b4402df8ade0
 parent		07a12a08005f3b5cd9337900a6551e450c07b515
 
-To adapt for u-boot usage, only the applicable files were copied and
-imported into the u-boot git repository.
-Omitted:
-* GPL - u-boot comes with a copy of the GPL license
-* test subdirectory - not directly useful for u-boot
+To adapt for U-Boot usage, only the applicable files were copied and
+imported into the U-Boot Git repository.
 
-After importing, other customizations were performed.  See the git log
-for details.
+Omitted:
+
+  * GPL - U-Boot comes with a copy of the GPL license
+  * test subdirectory - not directly useful for U-Boot
+
+After importing, other customizations were performed.  See the
+"git log" for details.
 
 Jerry Van Baren

--- a/lib/libfdt/fdt.c
+++ b/lib/libfdt/fdt.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>

--- a/lib/libfdt/fdt.c
+++ b/lib/libfdt/fdt.c
@@ -35,18 +35,19 @@ int fdt_check_header(const void *fdt)
 
 const void *fdt_offset_ptr(const void *fdt, int offset, unsigned int len)
 {
-	const char *p;
+	unsigned absoffset = offset + fdt_off_dt_struct(fdt);
+
+	if ((absoffset < offset)
+	    || ((absoffset + len) < absoffset)
+	    || (absoffset + len) > fdt_totalsize(fdt))
+		return NULL;
 
 	if (fdt_version(fdt) >= 0x11)
 		if (((offset + len) < offset)
 		    || ((offset + len) > fdt_size_dt_struct(fdt)))
 			return NULL;
 
-	p = _fdt_offset_ptr(fdt, offset);
-
-	if (p + len < p)
-		return NULL;
-	return p;
+	return _fdt_offset_ptr(fdt, offset);
 }
 
 uint32_t fdt_next_tag(const void *fdt, int startoffset, int *nextoffset)

--- a/lib/libfdt/fdt_addresses.c
+++ b/lib/libfdt/fdt_addresses.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2014 David Gibson <david@gibson.dropbear.id.au>
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>

--- a/lib/libfdt/fdt_empty_tree.c
+++ b/lib/libfdt/fdt_empty_tree.c
@@ -3,8 +3,7 @@
  * Copyright (C) 2012 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
-
+#include <libfdt_env.h>
 #include <fdt.h>
 #include <libfdt.h>
 

--- a/lib/libfdt/fdt_ro.c
+++ b/lib/libfdt/fdt_ro.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>
@@ -19,7 +19,7 @@ static int _fdt_nodename_eq(const void *fdt, int offset,
 {
 	const char *p = fdt_offset_ptr(fdt, offset + FDT_TAGSIZE, len+1);
 
-	if (! p)
+	if (!p)
 		/* short match */
 		return 0;
 
@@ -115,7 +115,7 @@ int fdt_subnode_offset(const void *fdt, int parentoffset,
 
 /*
  * Find the next of path seperator, note we need to search for both '/' and ':'
- * and then take the first one so that we do the rigth thing for e.g.
+ * and then take the first one so that we do the right thing for e.g.
  * "foo/bar:option" and "bar:option/otheroption", both of which happen, so
  * first searching for either ':' or '/' does not work.
  */
@@ -163,7 +163,7 @@ int fdt_path_offset(const void *fdt, const char *path)
 		if (*p == '\0' || *p == ':')
 			return offset;
 		q = fdt_path_next_seperator(p);
-		if (! q)
+		if (!q)
 			q = end;
 
 		offset = fdt_subnode_offset_namelen(fdt, offset, p, q-p);
@@ -273,7 +273,7 @@ const void *fdt_getprop_namelen(const void *fdt, int nodeoffset,
 	const struct fdt_property *prop;
 
 	prop = fdt_get_property_namelen(fdt, nodeoffset, name, namelen, lenp);
-	if (! prop)
+	if (!prop)
 		return NULL;
 
 	return prop->data;

--- a/lib/libfdt/fdt_rw.c
+++ b/lib/libfdt/fdt_rw.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>
@@ -168,7 +168,7 @@ static int _fdt_resize_property(void *fdt, int nodeoffset, const char *name,
 	int err;
 
 	*prop = fdt_get_property_w(fdt, nodeoffset, name, &oldlen);
-	if (! (*prop))
+	if (!(*prop))
 		return oldlen;
 
 	if ((err = _fdt_splice_struct(fdt, (*prop)->data, FDT_TAGALIGN(oldlen),
@@ -283,7 +283,7 @@ int fdt_delprop(void *fdt, int nodeoffset, const char *name)
 	FDT_RW_CHECK_HEADER(fdt);
 
 	prop = fdt_get_property_w(fdt, nodeoffset, name, &len);
-	if (! prop)
+	if (!prop)
 		return len;
 
 	proplen = sizeof(*prop) + FDT_TAGALIGN(len);

--- a/lib/libfdt/fdt_rw.c
+++ b/lib/libfdt/fdt_rw.c
@@ -58,9 +58,13 @@ static int _fdt_splice(void *fdt, void *splicepoint, int oldlen, int newlen)
 	char *p = splicepoint;
 	char *end = (char *)fdt + _fdt_data_size(fdt);
 
-	if (((p + oldlen) < p) || ((p + oldlen) > end))
+	if (oldlen < 0 || newlen < 0)
 		return -FDT_ERR_BADOFFSET;
-	if ((end - oldlen + newlen) > ((char *)fdt + fdt_totalsize(fdt)))
+	if (p < (char *)fdt || p > end)
+		return -FDT_ERR_BADOFFSET;
+	if (end - p < oldlen)
+		return -FDT_ERR_BADOFFSET;
+	if (_fdt_data_size(fdt) - oldlen + newlen > fdt_totalsize(fdt))
 		return -FDT_ERR_NOSPACE;
 	memmove(p + newlen, p + oldlen, end - p - oldlen);
 	return 0;

--- a/lib/libfdt/fdt_strerror.c
+++ b/lib/libfdt/fdt_strerror.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>

--- a/lib/libfdt/fdt_sw.c
+++ b/lib/libfdt/fdt_sw.c
@@ -3,8 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
-
+#include <libfdt_env.h>
 #include <fdt.h>
 #include <libfdt.h>
 

--- a/lib/libfdt/fdt_wip.c
+++ b/lib/libfdt/fdt_wip.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * SPDX-License-Identifier:	GPL-2.0+ BSD-2-Clause
  */
-#include "libfdt_env.h"
+#include <libfdt_env.h>
 
 #ifndef USE_HOSTCC
 #include <fdt.h>
@@ -21,7 +21,7 @@ int fdt_setprop_inplace(void *fdt, int nodeoffset, const char *name,
 	int proplen;
 
 	propval = fdt_getprop_w(fdt, nodeoffset, name, &proplen);
-	if (! propval)
+	if (!propval)
 		return proplen;
 
 	if (proplen != len)
@@ -45,7 +45,7 @@ int fdt_nop_property(void *fdt, int nodeoffset, const char *name)
 	int len;
 
 	prop = fdt_get_property_w(fdt, nodeoffset, name, &len);
-	if (! prop)
+	if (!prop)
 		return len;
 
 	_fdt_nop_region(prop, len + sizeof(*prop));


### PR DESCRIPTION
## What changed

- Backported targeted libfdt and FAT fixes from newer U-Boot history onto `u-boot-2016.03-at91`.
- Reworked suspicious pointer arithmetic patterns in UniPhier pinctrl, Broadcom GMAC, and Freescale SPL code.
- Hardened arithmetic and pointer checks in shared FAT, UBIFS, MTD/UBI, NAND, gzip, display, and libfdt code paths.

## Why

GitHub CodeQL currently reports a broad set of alerts against the default `u-boot-2016.03-at91` branch. This PR keeps the branch on the same old U-Boot baseline while reducing obvious static-analysis findings and importing low-risk upstream fixes where they cherry-pick cleanly.

This is repository hygiene only. It is not yet a proposal to change the Renos OS bootloader recipe or field-update behavior.

## Validation

- `git diff --check origin/u-boot-2016.03-at91..HEAD`
- `make O=/tmp/u-boot-at91-maint-config at91sam9m10g45ek_nandflash_config`
- `make O=/tmp/u-boot-at91-maint-config tools-only`

A full ARM target build was not run because no ARM cross compiler is available in the current shell `PATH`.
