### PR TITLE
[REN-10012] Preserve fw_printenv diagnostics options

### DIFF
--- a/test/env/test-fw-envtools.sh
+++ b/test/env/test-fw-envtools.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0+
+#
+# Validate the fw_printenv compatibility options used by Renos diagnostics.
+
+set -eu
+
+SRCTREE="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/u-boot-at91-fw-envtools.XXXXXX")"
+OUT="${1:-${WORK}/build}"
+JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
+FW_PRINTENV="${FW_PRINTENV:-}"
+
+case "${OUT}" in
+/*) ;;
+*) OUT="$(pwd)/${OUT}" ;;
+esac
+
+cleanup()
+{
+	rm -rf "${WORK}"
+}
+trap cleanup EXIT INT TERM
+
+if [ -z "${FW_PRINTENV}" ]; then
+	make -C "${SRCTREE}" O="${OUT}" tools-only_config >/dev/null
+	make -C "${SRCTREE}" O="${OUT}" -j"${JOBS}" envtools >/dev/null
+
+	FW_PRINTENV="${OUT}/tools/env/fw_printenv"
+fi
+
+case "${FW_PRINTENV}" in
+/*) ;;
+*) FW_PRINTENV="$(pwd)/${FW_PRINTENV}" ;;
+esac
+
+if [ ! -x "${FW_PRINTENV}" ]; then
+	echo "FAIL: fw_printenv is not executable: ${FW_PRINTENV}" >&2
+	exit 1
+fi
+
+python3 - "${WORK}" <<'PY'
+import binascii
+import struct
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+env_size = 0x2000
+
+def env_data(entries, data_size):
+    encoded = [f"{key}={value}".encode() for key, value in entries]
+    blob = b"\0".join(encoded) + b"\0\0"
+    if len(blob) > data_size:
+        raise SystemExit("fixture too large")
+    used = sum(len(entry) + 1 for entry in encoded)
+    return blob + b"\0" * (data_size - len(blob)), used
+
+def single(entries):
+    data, used = env_data(entries, env_size - 4)
+    return struct.pack("<I", binascii.crc32(data) & 0xffffffff) + data, used
+
+def redundant(entries, flag):
+    data, used = env_data(entries, env_size - 5)
+    return struct.pack("<I", binascii.crc32(data) & 0xffffffff) + bytes([flag]) + data, used
+
+def corrupt_crc(image):
+    return bytes([image[0] ^ 0xff]) + image[1:]
+
+single_img, single_used = single([
+    ("bootcmd", "run single"),
+    ("longvar", "abc def"),
+])
+setenv_img, _ = single([
+    ("bootcmd", "run old"),
+    ("longvar", "abc def"),
+])
+active_img, active_used = redundant([
+    ("bootcmd", "run active"),
+    ("side", "active"),
+], 2)
+fallback_img, fallback_used = redundant([
+    ("bootcmd", "run fallback"),
+    ("side", "fallback"),
+], 1)
+bad_fallback_img, _ = redundant([
+    ("bootcmd", "badcrc fallback"),
+], 1)
+bad_active_img, _ = redundant([
+    ("bootcmd", "badcrc active"),
+], 2)
+unterminated_data = b"A" * (env_size - 4)
+unterminated_img = (
+    struct.pack("<I", binascii.crc32(unterminated_data) & 0xffffffff)
+    + unterminated_data
+)
+malformed_tail_data = (
+    b"bootcmd=tail-present\0" +
+    b"B" * ((env_size - 4) - len(b"bootcmd=tail-present\0"))
+)
+malformed_tail_img = (
+    struct.pack("<I", binascii.crc32(malformed_tail_data) & 0xffffffff)
+    + malformed_tail_data
+)
+hidden_tail_data = (
+    b"\0hidden=1\0\0" +
+    b"\0" * ((env_size - 4) - len(b"\0hidden=1\0\0"))
+)
+hidden_tail_img = (
+    struct.pack("<I", binascii.crc32(hidden_tail_data) & 0xffffffff)
+    + hidden_tail_data
+)
+
+(root / "single.bin").write_bytes(single_img)
+(root / "setenv.bin").write_bytes(setenv_img)
+(root / "redundant.bin").write_bytes(active_img + fallback_img)
+(root / "bad-fallback.bin").write_bytes(active_img + corrupt_crc(bad_fallback_img))
+(root / "both-bad.bin").write_bytes(
+    corrupt_crc(bad_active_img) + corrupt_crc(bad_fallback_img)
+)
+(root / "unterminated.bin").write_bytes(unterminated_img)
+(root / "malformed-tail.bin").write_bytes(malformed_tail_img)
+(root / "hidden-tail.bin").write_bytes(hidden_tail_img)
+
+(root / "single.config").write_text(
+    f"{root / 'single.bin'} 0x0 0x{env_size:x}\n"
+)
+(root / "setenv.config").write_text(
+    f"{root / 'setenv.bin'} 0x0 0x{env_size:x}\n"
+)
+(root / "redundant.config").write_text(
+    f"{root / 'redundant.bin'} 0x0 0x{env_size:x}\n"
+    f"{root / 'redundant.bin'} 0x{env_size:x} 0x{env_size:x}\n"
+)
+(root / "bad-fallback.config").write_text(
+    f"{root / 'bad-fallback.bin'} 0x0 0x{env_size:x}\n"
+    f"{root / 'bad-fallback.bin'} 0x{env_size:x} 0x{env_size:x}\n"
+)
+(root / "both-bad.config").write_text(
+    f"{root / 'both-bad.bin'} 0x0 0x{env_size:x}\n"
+    f"{root / 'both-bad.bin'} 0x{env_size:x} 0x{env_size:x}\n"
+)
+(root / "unterminated.config").write_text(
+    f"{root / 'unterminated.bin'} 0x0 0x{env_size:x}\n"
+)
+(root / "malformed-tail.config").write_text(
+    f"{root / 'malformed-tail.bin'} 0x0 0x{env_size:x}\n"
+)
+(root / "hidden-tail.config").write_text(
+    f"{root / 'hidden-tail.bin'} 0x0 0x{env_size:x}\n"
+)
+
+(root / "single.used").write_text(f"{single_used}\n")
+(root / "active.used").write_text(f"{active_used}\n")
+(root / "fallback.used").write_text(f"{fallback_used}\n")
+PY
+
+fw()
+{
+	config="$1"
+	shift
+	"${FW_PRINTENV}" -l "${WORK}" -c "${config}" "$@"
+}
+
+fail()
+{
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+assert_eq()
+{
+	name="$1"
+	want="$2"
+	got="$3"
+	test "${got}" = "${want}" || fail "${name}: expected '${want}', got '${got}'"
+}
+
+single_config="${WORK}/single.config"
+setenv_config="${WORK}/setenv.config"
+redundant_config="${WORK}/redundant.config"
+bad_fallback_config="${WORK}/bad-fallback.config"
+both_bad_config="${WORK}/both-bad.config"
+unterminated_config="${WORK}/unterminated.config"
+malformed_tail_config="${WORK}/malformed-tail.config"
+hidden_tail_config="${WORK}/hidden-tail.config"
+fw_setenv="${WORK}/fw_setenv"
+
+ln -sf "${FW_PRINTENV}" "${fw_setenv}"
+
+assert_eq "single variable" "bootcmd=run single" \
+	"$(fw "${single_config}" bootcmd)"
+assert_eq "single value only" "abc def" \
+	"$(fw "${single_config}" -n longvar)"
+assert_eq "single used bytes" "$(cat "${WORK}/single.used")" \
+	"$(fw "${single_config}" -u "")"
+assert_eq "single offset" "0" \
+	"$(fw "${single_config}" -o)"
+
+"${fw_setenv}" -l "${WORK}" -c "${setenv_config}" newvar hello ||
+	fail "setenv create failed"
+assert_eq "setenv created variable" "newvar=hello" \
+	"$(fw "${setenv_config}" newvar)"
+"${fw_setenv}" -l "${WORK}" -c "${setenv_config}" bootcmd "run new" ||
+	fail "setenv overwrite failed"
+assert_eq "setenv overwritten variable" "bootcmd=run new" \
+	"$(fw "${setenv_config}" bootcmd)"
+
+if fw "${single_config}" -f bootcmd >/dev/null 2>"${WORK}/single-fallback.err"; then
+	fail "single fallback unexpectedly succeeded"
+fi
+grep -q "fallback environment requested without redundant environment" \
+	"${WORK}/single-fallback.err" ||
+	fail "single fallback error did not explain missing redundant environment"
+
+assert_eq "redundant active variable" "bootcmd=run active" \
+	"$(fw "${redundant_config}" bootcmd)"
+assert_eq "redundant fallback variable" "bootcmd=run fallback" \
+	"$(fw "${redundant_config}" -f bootcmd)"
+assert_eq "redundant fallback value only" "run fallback" \
+	"$(fw "${redundant_config}" -f -n bootcmd)"
+assert_eq "redundant active used bytes" "$(cat "${WORK}/active.used")" \
+	"$(fw "${redundant_config}" -u ignored)"
+assert_eq "redundant fallback used bytes" "$(cat "${WORK}/fallback.used")" \
+	"$(fw "${redundant_config}" -u -f ignored)"
+assert_eq "redundant active offset" "0" \
+	"$(fw "${redundant_config}" -o)"
+assert_eq "redundant fallback offset" "8192" \
+	"$(fw "${redundant_config}" -f -o)"
+
+assert_eq "bad fallback active variable" "bootcmd=run active" \
+	"$(fw "${bad_fallback_config}" bootcmd)"
+if fw "${bad_fallback_config}" -f bootcmd >/dev/null 2>"${WORK}/bad-fallback.err"; then
+	fail "bad-CRC fallback unexpectedly succeeded"
+fi
+grep -q "fallback environment has bad CRC" "${WORK}/bad-fallback.err" ||
+	fail "bad-CRC fallback error did not explain fallback CRC"
+
+if fw "${both_bad_config}" -f bootcmd >/dev/null 2>"${WORK}/both-bad.err"; then
+	fail "both-bad-CRC fallback unexpectedly succeeded"
+fi
+grep -q "fallback environment has bad CRC" "${WORK}/both-bad.err" ||
+	fail "both-bad-CRC fallback error did not explain fallback CRC"
+
+if fw "${unterminated_config}" -u ignored >/dev/null 2>"${WORK}/unterminated.err"; then
+	fail "unterminated environment used-size unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/unterminated.err" ||
+	fail "unterminated environment error did not explain termination"
+
+if fw "${unterminated_config}" bootcmd >/dev/null 2>"${WORK}/unterminated-lookup.err"; then
+	fail "unterminated environment lookup unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/unterminated-lookup.err" ||
+	fail "unterminated lookup error did not explain termination"
+
+if fw "${unterminated_config}" >/dev/null 2>"${WORK}/unterminated-print.err"; then
+	fail "unterminated environment print unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/unterminated-print.err" ||
+	fail "unterminated print error did not explain termination"
+
+if fw "${malformed_tail_config}" bootcmd >/dev/null 2>"${WORK}/malformed-tail-lookup.err"; then
+	fail "malformed-tail environment lookup unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/malformed-tail-lookup.err" ||
+	fail "malformed-tail lookup error did not explain termination"
+
+if "${fw_setenv}" -l "${WORK}" -c "${malformed_tail_config}" bootcmd new \
+	>/dev/null 2>"${WORK}/malformed-tail-setenv.err"; then
+	fail "malformed-tail setenv unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/malformed-tail-setenv.err" ||
+	fail "malformed-tail setenv error did not explain termination"
+
+if fw "${hidden_tail_config}" hidden >/dev/null 2>"${WORK}/hidden-tail-lookup.err"; then
+	fail "hidden-tail environment lookup unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/hidden-tail-lookup.err" ||
+	fail "hidden-tail lookup error did not explain termination"
+
+if "${fw_setenv}" -l "${WORK}" -c "${hidden_tail_config}" foo bar \
+	>/dev/null 2>"${WORK}/hidden-tail-setenv.err"; then
+	fail "hidden-tail setenv unexpectedly succeeded"
+fi
+grep -q "environment not terminated" "${WORK}/hidden-tail-setenv.err" ||
+	fail "hidden-tail setenv error did not explain termination"
+
+echo "fw envtools compatibility tests: OK"

--- a/test/env/test-fw-envtools.sh
+++ b/test/env/test-fw-envtools.sh
@@ -212,6 +212,17 @@ assert_eq()
 	test "${got}" = "${want}" || fail "${name}: expected '${want}', got '${got}'"
 }
 
+assert_cmd_eq()
+{
+	name="$1"
+	want="$2"
+	shift 2
+	if ! got="$("$@")"; then
+		fail "${name}: command failed"
+	fi
+	assert_eq "${name}" "${want}" "${got}"
+}
+
 single_config="${WORK}/single.config"
 setenv_config="${WORK}/setenv.config"
 redundant_config="${WORK}/redundant.config"
@@ -226,23 +237,23 @@ fw_setenv="${WORK}/fw_setenv"
 
 ln -sf "${FW_PRINTENV}" "${fw_setenv}"
 
-assert_eq "single variable" "bootcmd=run single" \
-	"$(fw "${single_config}" bootcmd)"
-assert_eq "single value only" "abc def" \
-	"$(fw "${single_config}" -n longvar)"
-assert_eq "single used bytes" "$(cat "${WORK}/single.used")" \
-	"$(fw "${single_config}" -u "")"
-assert_eq "single offset" "0" \
-	"$(fw "${single_config}" -o)"
+assert_cmd_eq "single variable" "bootcmd=run single" \
+	fw "${single_config}" bootcmd
+assert_cmd_eq "single value only" "abc def" \
+	fw "${single_config}" -n longvar
+assert_cmd_eq "single used bytes" "$(cat "${WORK}/single.used")" \
+	fw "${single_config}" -u ""
+assert_cmd_eq "single offset" "0" \
+	fw "${single_config}" -o
 
 "${fw_setenv}" -l "${WORK}" -c "${setenv_config}" newvar hello ||
 	fail "setenv create failed"
-assert_eq "setenv created variable" "newvar=hello" \
-	"$(fw "${setenv_config}" newvar)"
+assert_cmd_eq "setenv created variable" "newvar=hello" \
+	fw "${setenv_config}" newvar
 "${fw_setenv}" -l "${WORK}" -c "${setenv_config}" bootcmd "run new" ||
 	fail "setenv overwrite failed"
-assert_eq "setenv overwritten variable" "bootcmd=run new" \
-	"$(fw "${setenv_config}" bootcmd)"
+assert_cmd_eq "setenv overwritten variable" "bootcmd=run new" \
+	fw "${setenv_config}" bootcmd
 
 if fw "${single_config}" -f bootcmd >/dev/null 2>"${WORK}/single-fallback.err"; then
 	fail "single fallback unexpectedly succeeded"
@@ -251,53 +262,53 @@ grep -q "fallback environment requested without redundant environment" \
 	"${WORK}/single-fallback.err" ||
 	fail "single fallback error did not explain missing redundant environment"
 
-assert_eq "redundant active variable" "bootcmd=run active" \
-	"$(fw "${redundant_config}" bootcmd)"
-assert_eq "redundant fallback variable" "bootcmd=run fallback" \
-	"$(fw "${redundant_config}" -f bootcmd)"
-assert_eq "redundant fallback value only" "run fallback" \
-	"$(fw "${redundant_config}" -f -n bootcmd)"
-assert_eq "redundant active used bytes" "$(cat "${WORK}/active.used")" \
-	"$(fw "${redundant_config}" -u ignored)"
-assert_eq "redundant active used bytes without variable" "$(cat "${WORK}/active.used")" \
-	"$(fw "${redundant_config}" -u)"
-assert_eq "redundant fallback used bytes" "$(cat "${WORK}/fallback.used")" \
-	"$(fw "${redundant_config}" -u -f ignored)"
-assert_eq "redundant active offset" "0" \
-	"$(fw "${redundant_config}" -o)"
-assert_eq "redundant fallback offset" "8192" \
-	"$(fw "${redundant_config}" -f -o)"
-assert_eq "redundant long used bytes without variable" "$(cat "${WORK}/active.used")" \
-	"$(fw "${redundant_config}" --used)"
-assert_eq "redundant long active offset" "0" \
-	"$(fw "${redundant_config}" --offset)"
-assert_eq "redundant long fallback offset" "8192" \
-	"$(fw "${redundant_config}" --fallback --offset)"
-assert_eq "redundant long fallback value only" "run fallback" \
-	"$(fw "${redundant_config}" --fallback --noheader bootcmd)"
+assert_cmd_eq "redundant active variable" "bootcmd=run active" \
+	fw "${redundant_config}" bootcmd
+assert_cmd_eq "redundant fallback variable" "bootcmd=run fallback" \
+	fw "${redundant_config}" -f bootcmd
+assert_cmd_eq "redundant fallback value only" "run fallback" \
+	fw "${redundant_config}" -f -n bootcmd
+assert_cmd_eq "redundant active used bytes" "$(cat "${WORK}/active.used")" \
+	fw "${redundant_config}" -u ignored
+assert_cmd_eq "redundant active used bytes without variable" "$(cat "${WORK}/active.used")" \
+	fw "${redundant_config}" -u
+assert_cmd_eq "redundant fallback used bytes" "$(cat "${WORK}/fallback.used")" \
+	fw "${redundant_config}" -u -f ignored
+assert_cmd_eq "redundant active offset" "0" \
+	fw "${redundant_config}" -o
+assert_cmd_eq "redundant fallback offset" "8192" \
+	fw "${redundant_config}" -f -o
+assert_cmd_eq "redundant long used bytes without variable" "$(cat "${WORK}/active.used")" \
+	fw "${redundant_config}" --used
+assert_cmd_eq "redundant long active offset" "0" \
+	fw "${redundant_config}" --offset
+assert_cmd_eq "redundant long fallback offset" "8192" \
+	fw "${redundant_config}" --fallback --offset
+assert_cmd_eq "redundant long fallback value only" "run fallback" \
+	fw "${redundant_config}" --fallback --noheader bootcmd
 if fw "${redundant_config}" -u -o >/dev/null 2>"${WORK}/used-offset.err"; then
 	fail "combined used and offset unexpectedly succeeded"
 fi
 grep -q "cannot be used together" "${WORK}/used-offset.err" ||
 	fail "combined used and offset error did not explain invalid option mix"
 
-assert_eq "reversed active variable" "bootcmd=run slot1" \
-	"$(fw "${reversed_config}" bootcmd)"
-assert_eq "reversed fallback variable" "bootcmd=run slot0" \
-	"$(fw "${reversed_config}" -f bootcmd)"
-assert_eq "reversed active used bytes" "$(cat "${WORK}/slot1.used")" \
-	"$(fw "${reversed_config}" -u ignored)"
-assert_eq "reversed fallback used bytes" "$(cat "${WORK}/slot0.used")" \
-	"$(fw "${reversed_config}" -f -u ignored)"
-assert_eq "reversed active offset" "8192" \
-	"$(fw "${reversed_config}" -o)"
-assert_eq "reversed fallback offset" "0" \
-	"$(fw "${reversed_config}" -f -o)"
+assert_cmd_eq "reversed active variable" "bootcmd=run slot1" \
+	fw "${reversed_config}" bootcmd
+assert_cmd_eq "reversed fallback variable" "bootcmd=run slot0" \
+	fw "${reversed_config}" -f bootcmd
+assert_cmd_eq "reversed active used bytes" "$(cat "${WORK}/slot1.used")" \
+	fw "${reversed_config}" -u ignored
+assert_cmd_eq "reversed fallback used bytes" "$(cat "${WORK}/slot0.used")" \
+	fw "${reversed_config}" -f -u ignored
+assert_cmd_eq "reversed active offset" "8192" \
+	fw "${reversed_config}" -o
+assert_cmd_eq "reversed fallback offset" "0" \
+	fw "${reversed_config}" -f -o
 
-assert_eq "bad fallback active variable" "bootcmd=run active" \
-	"$(fw "${bad_fallback_config}" bootcmd)"
-assert_eq "bad fallback offset remains available" "8192" \
-	"$(fw "${bad_fallback_config}" -f -o)"
+assert_cmd_eq "bad fallback active variable" "bootcmd=run active" \
+	fw "${bad_fallback_config}" bootcmd
+assert_cmd_eq "bad fallback offset remains available" "8192" \
+	fw "${bad_fallback_config}" -f -o
 if fw "${bad_fallback_config}" -f -u -o >/dev/null 2>"${WORK}/bad-fallback-used-offset.err"; then
 	fail "bad-CRC fallback used+offset unexpectedly succeeded"
 fi
@@ -309,10 +320,10 @@ fi
 grep -q "fallback environment has bad CRC" "${WORK}/bad-fallback.err" ||
 	fail "bad-CRC fallback error did not explain fallback CRC"
 
-assert_eq "active-bad valid active variable" "bootcmd=run slot1" \
-	"$(fw "${active_bad_config}" bootcmd)"
-assert_eq "active-bad fallback offset remains available" "0" \
-	"$(fw "${active_bad_config}" -f -o)"
+assert_cmd_eq "active-bad valid active variable" "bootcmd=run slot1" \
+	fw "${active_bad_config}" bootcmd
+assert_cmd_eq "active-bad fallback offset remains available" "0" \
+	fw "${active_bad_config}" -f -o
 if fw "${active_bad_config}" -f bootcmd >/dev/null 2>"${WORK}/active-bad.err"; then
 	fail "active-bad fallback unexpectedly succeeded"
 fi
@@ -348,8 +359,8 @@ if fw "${malformed_tail_config}" bootcmd >/dev/null 2>"${WORK}/malformed-tail-lo
 fi
 grep -q "environment not terminated" "${WORK}/malformed-tail-lookup.err" ||
 	fail "malformed-tail lookup error did not explain termination"
-assert_eq "malformed-tail offset remains available" "0" \
-	"$(fw "${malformed_tail_config}" -o)"
+assert_cmd_eq "malformed-tail offset remains available" "0" \
+	fw "${malformed_tail_config}" -o
 
 if "${fw_setenv}" -l "${WORK}" -c "${malformed_tail_config}" bootcmd new \
 	>/dev/null 2>"${WORK}/malformed-tail-setenv.err"; then

--- a/test/env/test-fw-envtools.sh
+++ b/test/env/test-fw-envtools.sh
@@ -7,17 +7,29 @@ set -eu
 
 SRCTREE="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/u-boot-at91-fw-envtools.XXXXXX")"
-OUT="${1:-${WORK}/build}"
+OUT_ARG="${1:-}"
+OUT="${OUT_ARG:-${WORK}/build}"
 JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
 FW_PRINTENV="${FW_PRINTENV:-}"
+CLEAN_OUT=0
 
 case "${OUT}" in
 /*) ;;
 *) OUT="$(pwd)/${OUT}" ;;
 esac
 
+if [ -z "${FW_PRINTENV}" ] && [ -n "${OUT_ARG}" ] && [ ! -e "${OUT}" ]; then
+	CLEAN_OUT=1
+fi
+
 cleanup()
 {
+	if [ "${CLEAN_OUT}" -eq 1 ]; then
+		case "${OUT}" in
+		"${WORK}"|"${WORK}"/*) ;;
+		*) rm -rf "${OUT}" ;;
+		esac
+	fi
 	rm -rf "${WORK}"
 }
 trap cleanup EXIT INT TERM
@@ -56,13 +68,15 @@ def env_data(entries, data_size):
     used = sum(len(entry) + 1 for entry in encoded)
     return blob + b"\0" * (data_size - len(blob)), used
 
+# envtools reads the CRC through the host C struct, so these file-backed
+# regression fixtures intentionally use host-native uint32_t byte order.
 def single(entries):
     data, used = env_data(entries, env_size - 4)
-    return struct.pack("<I", binascii.crc32(data) & 0xffffffff) + data, used
+    return struct.pack("=I", binascii.crc32(data) & 0xffffffff) + data, used
 
 def redundant(entries, flag):
     data, used = env_data(entries, env_size - 5)
-    return struct.pack("<I", binascii.crc32(data) & 0xffffffff) + bytes([flag]) + data, used
+    return struct.pack("=I", binascii.crc32(data) & 0xffffffff) + bytes([flag]) + data, used
 
 def corrupt_crc(image):
     return bytes([image[0] ^ 0xff]) + image[1:]
@@ -79,10 +93,20 @@ active_img, active_used = redundant([
     ("bootcmd", "run active"),
     ("side", "active"),
 ], 2)
+# File-backed fixtures use MTD_ABSENT, which selects FLAG_INCREMENTAL: higher
+# flag wins, so the active page uses 2 and the fallback page uses 1.
 fallback_img, fallback_used = redundant([
     ("bootcmd", "run fallback"),
     ("side", "fallback"),
 ], 1)
+slot0_img, slot0_used = redundant([
+    ("bootcmd", "run slot0"),
+    ("side", "slot0"),
+], 1)
+slot1_img, slot1_used = redundant([
+    ("bootcmd", "run slot1"),
+    ("side", "slot1"),
+], 2)
 bad_fallback_img, _ = redundant([
     ("bootcmd", "badcrc fallback"),
 ], 1)
@@ -91,7 +115,7 @@ bad_active_img, _ = redundant([
 ], 2)
 unterminated_data = b"A" * (env_size - 4)
 unterminated_img = (
-    struct.pack("<I", binascii.crc32(unterminated_data) & 0xffffffff)
+    struct.pack("=I", binascii.crc32(unterminated_data) & 0xffffffff)
     + unterminated_data
 )
 malformed_tail_data = (
@@ -99,7 +123,7 @@ malformed_tail_data = (
     b"B" * ((env_size - 4) - len(b"bootcmd=tail-present\0"))
 )
 malformed_tail_img = (
-    struct.pack("<I", binascii.crc32(malformed_tail_data) & 0xffffffff)
+    struct.pack("=I", binascii.crc32(malformed_tail_data) & 0xffffffff)
     + malformed_tail_data
 )
 hidden_tail_data = (
@@ -107,14 +131,16 @@ hidden_tail_data = (
     b"\0" * ((env_size - 4) - len(b"\0hidden=1\0\0"))
 )
 hidden_tail_img = (
-    struct.pack("<I", binascii.crc32(hidden_tail_data) & 0xffffffff)
+    struct.pack("=I", binascii.crc32(hidden_tail_data) & 0xffffffff)
     + hidden_tail_data
 )
 
 (root / "single.bin").write_bytes(single_img)
 (root / "setenv.bin").write_bytes(setenv_img)
 (root / "redundant.bin").write_bytes(active_img + fallback_img)
+(root / "reversed.bin").write_bytes(slot0_img + slot1_img)
 (root / "bad-fallback.bin").write_bytes(active_img + corrupt_crc(bad_fallback_img))
+(root / "active-bad.bin").write_bytes(corrupt_crc(slot0_img) + slot1_img)
 (root / "both-bad.bin").write_bytes(
     corrupt_crc(bad_active_img) + corrupt_crc(bad_fallback_img)
 )
@@ -132,9 +158,17 @@ hidden_tail_img = (
     f"{root / 'redundant.bin'} 0x0 0x{env_size:x}\n"
     f"{root / 'redundant.bin'} 0x{env_size:x} 0x{env_size:x}\n"
 )
+(root / "reversed.config").write_text(
+    f"{root / 'reversed.bin'} 0x0 0x{env_size:x}\n"
+    f"{root / 'reversed.bin'} 0x{env_size:x} 0x{env_size:x}\n"
+)
 (root / "bad-fallback.config").write_text(
     f"{root / 'bad-fallback.bin'} 0x0 0x{env_size:x}\n"
     f"{root / 'bad-fallback.bin'} 0x{env_size:x} 0x{env_size:x}\n"
+)
+(root / "active-bad.config").write_text(
+    f"{root / 'active-bad.bin'} 0x0 0x{env_size:x}\n"
+    f"{root / 'active-bad.bin'} 0x{env_size:x} 0x{env_size:x}\n"
 )
 (root / "both-bad.config").write_text(
     f"{root / 'both-bad.bin'} 0x0 0x{env_size:x}\n"
@@ -153,6 +187,8 @@ hidden_tail_img = (
 (root / "single.used").write_text(f"{single_used}\n")
 (root / "active.used").write_text(f"{active_used}\n")
 (root / "fallback.used").write_text(f"{fallback_used}\n")
+(root / "slot0.used").write_text(f"{slot0_used}\n")
+(root / "slot1.used").write_text(f"{slot1_used}\n")
 PY
 
 fw()
@@ -179,7 +215,9 @@ assert_eq()
 single_config="${WORK}/single.config"
 setenv_config="${WORK}/setenv.config"
 redundant_config="${WORK}/redundant.config"
+reversed_config="${WORK}/reversed.config"
 bad_fallback_config="${WORK}/bad-fallback.config"
+active_bad_config="${WORK}/active-bad.config"
 both_bad_config="${WORK}/both-bad.config"
 unterminated_config="${WORK}/unterminated.config"
 malformed_tail_config="${WORK}/malformed-tail.config"
@@ -221,20 +259,65 @@ assert_eq "redundant fallback value only" "run fallback" \
 	"$(fw "${redundant_config}" -f -n bootcmd)"
 assert_eq "redundant active used bytes" "$(cat "${WORK}/active.used")" \
 	"$(fw "${redundant_config}" -u ignored)"
+assert_eq "redundant active used bytes without variable" "$(cat "${WORK}/active.used")" \
+	"$(fw "${redundant_config}" -u)"
 assert_eq "redundant fallback used bytes" "$(cat "${WORK}/fallback.used")" \
 	"$(fw "${redundant_config}" -u -f ignored)"
 assert_eq "redundant active offset" "0" \
 	"$(fw "${redundant_config}" -o)"
 assert_eq "redundant fallback offset" "8192" \
 	"$(fw "${redundant_config}" -f -o)"
+assert_eq "redundant long used bytes without variable" "$(cat "${WORK}/active.used")" \
+	"$(fw "${redundant_config}" --used)"
+assert_eq "redundant long active offset" "0" \
+	"$(fw "${redundant_config}" --offset)"
+assert_eq "redundant long fallback offset" "8192" \
+	"$(fw "${redundant_config}" --fallback --offset)"
+assert_eq "redundant long fallback value only" "run fallback" \
+	"$(fw "${redundant_config}" --fallback --noheader bootcmd)"
+if fw "${redundant_config}" -u -o >/dev/null 2>"${WORK}/used-offset.err"; then
+	fail "combined used and offset unexpectedly succeeded"
+fi
+grep -q "cannot be used together" "${WORK}/used-offset.err" ||
+	fail "combined used and offset error did not explain invalid option mix"
+
+assert_eq "reversed active variable" "bootcmd=run slot1" \
+	"$(fw "${reversed_config}" bootcmd)"
+assert_eq "reversed fallback variable" "bootcmd=run slot0" \
+	"$(fw "${reversed_config}" -f bootcmd)"
+assert_eq "reversed active used bytes" "$(cat "${WORK}/slot1.used")" \
+	"$(fw "${reversed_config}" -u ignored)"
+assert_eq "reversed fallback used bytes" "$(cat "${WORK}/slot0.used")" \
+	"$(fw "${reversed_config}" -f -u ignored)"
+assert_eq "reversed active offset" "8192" \
+	"$(fw "${reversed_config}" -o)"
+assert_eq "reversed fallback offset" "0" \
+	"$(fw "${reversed_config}" -f -o)"
 
 assert_eq "bad fallback active variable" "bootcmd=run active" \
 	"$(fw "${bad_fallback_config}" bootcmd)"
+assert_eq "bad fallback offset remains available" "8192" \
+	"$(fw "${bad_fallback_config}" -f -o)"
+if fw "${bad_fallback_config}" -f -u -o >/dev/null 2>"${WORK}/bad-fallback-used-offset.err"; then
+	fail "bad-CRC fallback used+offset unexpectedly succeeded"
+fi
+grep -q "cannot be used together" "${WORK}/bad-fallback-used-offset.err" ||
+	fail "bad-CRC fallback used+offset error did not explain invalid option mix"
 if fw "${bad_fallback_config}" -f bootcmd >/dev/null 2>"${WORK}/bad-fallback.err"; then
 	fail "bad-CRC fallback unexpectedly succeeded"
 fi
 grep -q "fallback environment has bad CRC" "${WORK}/bad-fallback.err" ||
 	fail "bad-CRC fallback error did not explain fallback CRC"
+
+assert_eq "active-bad valid active variable" "bootcmd=run slot1" \
+	"$(fw "${active_bad_config}" bootcmd)"
+assert_eq "active-bad fallback offset remains available" "0" \
+	"$(fw "${active_bad_config}" -f -o)"
+if fw "${active_bad_config}" -f bootcmd >/dev/null 2>"${WORK}/active-bad.err"; then
+	fail "active-bad fallback unexpectedly succeeded"
+fi
+grep -q "fallback environment has bad CRC" "${WORK}/active-bad.err" ||
+	fail "active-bad fallback error did not explain fallback CRC"
 
 if fw "${both_bad_config}" -f bootcmd >/dev/null 2>"${WORK}/both-bad.err"; then
 	fail "both-bad-CRC fallback unexpectedly succeeded"
@@ -265,6 +348,8 @@ if fw "${malformed_tail_config}" bootcmd >/dev/null 2>"${WORK}/malformed-tail-lo
 fi
 grep -q "environment not terminated" "${WORK}/malformed-tail-lookup.err" ||
 	fail "malformed-tail lookup error did not explain termination"
+assert_eq "malformed-tail offset remains available" "0" \
+	"$(fw "${malformed_tail_config}" -o)"
 
 if "${fw_setenv}" -l "${WORK}" -c "${malformed_tail_config}" bootcmd new \
 	>/dev/null 2>"${WORK}/malformed-tail-setenv.err"; then

--- a/tools/env/fw_env.c
+++ b/tools/env/fw_env.c
@@ -1691,34 +1691,34 @@ static int fw_env_open_selected(struct env_opts *opts, int use_fallback,
 		 * more, if we are writing, we will re-calculate CRC and update
 		 * flags before writing out
 		 */
-			if (use_fallback) {
-				dev_current = !dev_current;
-				if (!metadata_only &&
-				    ((dev_current && !crc1_ok) ||
-				     (!dev_current && !crc0_ok))) {
-					fprintf(stderr,
-						"## Error: fallback environment has bad CRC\n");
+		if (use_fallback) {
+			dev_current = !dev_current;
+			if (!metadata_only &&
+			    ((dev_current && !crc1_ok) ||
+			     (!dev_current && !crc0_ok))) {
+				fprintf(stderr,
+					"## Error: fallback environment has bad CRC\n");
+				ret = -EINVAL;
+				goto open_cleanup;
+			}
+		}
+		if (!metadata_only) {
+			if (dev_current) {
+				if (!fw_env_data_end(redundant1->data,
+						     redundant1->data + ENV_SIZE,
+						     "environment")) {
+					ret = -EINVAL;
+					goto open_cleanup;
+				}
+			} else {
+				if (!fw_env_data_end(redundant0->data,
+						     redundant0->data + ENV_SIZE,
+						     "environment")) {
 					ret = -EINVAL;
 					goto open_cleanup;
 				}
 			}
-			if (!metadata_only) {
-				if (dev_current) {
-					if (!fw_env_data_end(redundant1->data,
-							     redundant1->data + ENV_SIZE,
-							     "environment")) {
-						ret = -EINVAL;
-						goto open_cleanup;
-					}
-				} else {
-					if (!fw_env_data_end(redundant0->data,
-							     redundant0->data + ENV_SIZE,
-							     "environment")) {
-						ret = -EINVAL;
-						goto open_cleanup;
-					}
-				}
-			}
+		}
 
 		if (dev_current) {
 			environment.image = buf1;

--- a/tools/env/fw_env.c
+++ b/tools/env/fw_env.c
@@ -121,7 +121,8 @@ static struct environment environment = {
 };
 
 static int have_redund_env;
-static int fw_env_open_selected(struct env_opts *opts, int use_fallback);
+static int fw_env_open_selected(struct env_opts *opts, int use_fallback,
+				int metadata_only);
 
 #define DEFAULT_ENV_INSTANCE_STATIC
 #include <env_default.h>
@@ -531,11 +532,16 @@ int fw_printenv_ext(int argc, char *argv[], int value_only,
 			"## Error: `-n'/`--noheader' option requires exactly one argument\n");
 		return -1;
 	}
+	if (print_used && print_offset) {
+		fprintf(stderr,
+			"## Error: `-u'/`--used' and `-o'/`--offset' cannot be used together\n");
+		return -1;
+	}
 
 	if (!opts)
 		opts = &default_opts;
 
-	if (fw_env_open_selected(opts, use_fallback))
+	if (fw_env_open_selected(opts, use_fallback, print_offset))
 		return -1;
 
 	if (print_used) {
@@ -1513,7 +1519,8 @@ static int flash_io(int mode, void *buf, size_t count)
 /*
  * Prevent confusion if running from erased flash memory
  */
-static int fw_env_open_selected(struct env_opts *opts, int use_fallback)
+static int fw_env_open_selected(struct env_opts *opts, int use_fallback,
+				int metadata_only)
 {
 	int crc0, crc0_ok;
 	unsigned char flag0;
@@ -1565,7 +1572,8 @@ static int fw_env_open_selected(struct env_opts *opts, int use_fallback)
 			       sizeof(default_environment));
 			environment.dirty = 1;
 		}
-		if (!fw_env_data_end(single->data, single->data + ENV_SIZE,
+		if (!metadata_only &&
+		    !fw_env_data_end(single->data, single->data + ENV_SIZE,
 				     "environment")) {
 			ret = -EINVAL;
 			goto open_cleanup;
@@ -1683,31 +1691,34 @@ static int fw_env_open_selected(struct env_opts *opts, int use_fallback)
 		 * more, if we are writing, we will re-calculate CRC and update
 		 * flags before writing out
 		 */
-		if (use_fallback) {
-			dev_current = !dev_current;
-			if ((dev_current && !crc1_ok) ||
-			    (!dev_current && !crc0_ok)) {
-				fprintf(stderr,
-					"## Error: fallback environment has bad CRC\n");
-				ret = -EINVAL;
-				goto open_cleanup;
+			if (use_fallback) {
+				dev_current = !dev_current;
+				if (!metadata_only &&
+				    ((dev_current && !crc1_ok) ||
+				     (!dev_current && !crc0_ok))) {
+					fprintf(stderr,
+						"## Error: fallback environment has bad CRC\n");
+					ret = -EINVAL;
+					goto open_cleanup;
+				}
 			}
-		}
-		if (dev_current) {
-			if (!fw_env_data_end(redundant1->data,
-					     redundant1->data + ENV_SIZE,
-					     "environment")) {
-				ret = -EINVAL;
-				goto open_cleanup;
+			if (!metadata_only) {
+				if (dev_current) {
+					if (!fw_env_data_end(redundant1->data,
+							     redundant1->data + ENV_SIZE,
+							     "environment")) {
+						ret = -EINVAL;
+						goto open_cleanup;
+					}
+				} else {
+					if (!fw_env_data_end(redundant0->data,
+							     redundant0->data + ENV_SIZE,
+							     "environment")) {
+						ret = -EINVAL;
+						goto open_cleanup;
+					}
+				}
 			}
-		} else {
-			if (!fw_env_data_end(redundant0->data,
-					     redundant0->data + ENV_SIZE,
-					     "environment")) {
-				ret = -EINVAL;
-				goto open_cleanup;
-			}
-		}
 
 		if (dev_current) {
 			environment.image = buf1;
@@ -1737,7 +1748,7 @@ static int fw_env_open_selected(struct env_opts *opts, int use_fallback)
 
 int fw_env_open(struct env_opts *opts)
 {
-	return fw_env_open_selected(opts, 0);
+	return fw_env_open_selected(opts, 0, 0);
 }
 
 /*

--- a/tools/env/fw_env.c
+++ b/tools/env/fw_env.c
@@ -121,6 +121,7 @@ static struct environment environment = {
 };
 
 static int have_redund_env;
+static int fw_env_open_selected(struct env_opts *opts, int use_fallback);
 
 #define DEFAULT_ENV_INSTANCE_STATIC
 #include <env_default.h>
@@ -393,6 +394,50 @@ static char *envmatch(char *s1, char *s2)
 	return NULL;
 }
 
+static char *fw_env_entry_end(char *env, char *end, const char *label)
+{
+	char *nxt;
+
+	if (env >= end)
+		goto unterminated;
+
+	nxt = memchr(env, '\0', end - env);
+	if (!nxt)
+		goto unterminated;
+
+	return nxt;
+
+unterminated:
+	fprintf(stderr, "## Error: %s not terminated\n", label);
+	return NULL;
+}
+
+static char *fw_env_data_end(char *data, char *end, const char *label)
+{
+	char *env, *nxt;
+
+	for (env = data; env < end && *env; env = nxt + 1) {
+		nxt = fw_env_entry_end(env, end, label);
+		if (!nxt)
+			return NULL;
+		if (nxt + 1 >= end)
+			goto unterminated;
+		if (*(nxt + 1) == '\0')
+			return nxt;
+	}
+
+	if (env < end) {
+		if (env + 1 >= end)
+			goto unterminated;
+		if (*(env + 1) == '\0')
+			return env;
+	}
+
+unterminated:
+	fprintf(stderr, "## Error: %s not terminated\n", label);
+	return NULL;
+}
+
 /**
  * Search the environment for a variable.
  * Return the value, if found, or NULL, if not found.
@@ -400,22 +445,22 @@ static char *envmatch(char *s1, char *s2)
 char *fw_getenv(char *name)
 {
 	char *env, *nxt;
+	char *end = environment.data + ENV_SIZE;
 
-	for (env = environment.data; *env; env = nxt + 1) {
+	for (env = environment.data; env < end && *env; env = nxt + 1) {
 		char *val;
 
-		for (nxt = env; *nxt; ++nxt) {
-			if (nxt >= &environment.data[ENV_SIZE]) {
-				fprintf(stderr, "## Error: "
-					"environment not terminated\n");
-				return NULL;
-			}
-		}
+		nxt = fw_env_entry_end(env, end, "environment");
+		if (!nxt)
+			return NULL;
+
 		val = envmatch(name, env);
 		if (!val)
 			continue;
 		return val;
 	}
+	if (env >= end)
+		fw_env_entry_end(env, end, "environment");
 	return NULL;
 }
 
@@ -426,34 +471,62 @@ char *fw_getenv(char *name)
 char *fw_getdefenv(char *name)
 {
 	char *env, *nxt;
+	char *end = default_environment + sizeof(default_environment);
 
-	for (env = default_environment; *env; env = nxt + 1) {
+	for (env = default_environment; env < end && *env; env = nxt + 1) {
 		char *val;
 
-		for (nxt = env; *nxt; ++nxt) {
-			if (nxt >= &default_environment[ENV_SIZE]) {
-				fprintf(stderr, "## Error: "
-					"default environment not terminated\n");
-				return NULL;
-			}
-		}
+		nxt = fw_env_entry_end(env, end, "default environment");
+		if (!nxt)
+			return NULL;
+
 		val = envmatch(name, env);
 		if (!val)
 			continue;
 		return val;
 	}
+	if (env >= end)
+		fw_env_entry_end(env, end, "default environment");
 	return NULL;
+}
+
+static int fw_printenv_used(void)
+{
+	unsigned long size = 0;
+	char *env;
+	char *end = environment.data + ENV_SIZE;
+
+	for (env = environment.data; env < end && *env;) {
+		char *nxt = fw_env_entry_end(env, end, "environment");
+
+		if (!nxt)
+			return -1;
+
+		size += nxt - env + 1;
+		env = nxt + 1;
+	}
+	if (env >= end) {
+		fw_env_entry_end(env, end, "environment");
+		return -1;
+	}
+
+	printf("%lu\n", size);
+	return 0;
 }
 
 /*
  * Print the current definition of one, or more, or all
  * environment variables
  */
-int fw_printenv(int argc, char *argv[], int value_only, struct env_opts *opts)
+int fw_printenv_ext(int argc, char *argv[], int value_only,
+		    struct env_opts *opts, const struct fw_printenv_opts *print_opts)
 {
 	int i, rc = 0;
+	int print_used = print_opts && print_opts->print_used;
+	int print_offset = print_opts && print_opts->print_offset;
+	int use_fallback = print_opts && print_opts->use_fallback;
 
-	if (value_only && argc != 1) {
+	if (value_only && argc != 1 && !print_used && !print_offset) {
 		fprintf(stderr,
 			"## Error: `-n'/`--noheader' option requires exactly one argument\n");
 		return -1;
@@ -462,24 +535,39 @@ int fw_printenv(int argc, char *argv[], int value_only, struct env_opts *opts)
 	if (!opts)
 		opts = &default_opts;
 
-	if (fw_env_open(opts))
+	if (fw_env_open_selected(opts, use_fallback))
 		return -1;
+
+	if (print_used) {
+		rc = fw_printenv_used();
+		fw_env_close(opts);
+		return rc;
+	}
+
+	if (print_offset) {
+		printf("%lld\n", DEVOFFSET(dev_current));
+		fw_env_close(opts);
+		return 0;
+	}
 
 	if (argc == 0) {	/* Print all env variables  */
 		char *env, *nxt;
-		for (env = environment.data; *env; env = nxt + 1) {
-			for (nxt = env; *nxt; ++nxt) {
-				if (nxt >= &environment.data[ENV_SIZE]) {
-					fprintf(stderr, "## Error: "
-						"environment not terminated\n");
-					return -1;
-				}
-			}
+		char *end = environment.data + ENV_SIZE;
 
+		for (env = environment.data; env < end && *env; env = nxt + 1) {
+			nxt = fw_env_entry_end(env, end, "environment");
+			if (!nxt) {
+				rc = -1;
+				break;
+			}
 			printf("%s\n", env);
 		}
+		if (env >= end) {
+			fw_env_entry_end(env, end, "environment");
+			rc = -1;
+		}
 		fw_env_close(opts);
-		return 0;
+		return rc;
 	}
 
 	for (i = 0; i < argc; ++i) {	/* print a subset of env variables */
@@ -504,6 +592,11 @@ int fw_printenv(int argc, char *argv[], int value_only, struct env_opts *opts)
 	fw_env_close(opts);
 
 	return rc;
+}
+
+int fw_printenv(int argc, char *argv[], int value_only, struct env_opts *opts)
+{
+	return fw_printenv_ext(argc, argv, value_only, opts, NULL);
 }
 
 int fw_env_flush(struct env_opts *opts)
@@ -537,24 +630,27 @@ int fw_env_write(char *name, char *value)
 {
 	int len;
 	char *env, *nxt;
+	char *end = environment.data + ENV_SIZE;
 	char *oldval = NULL;
 	int deleting, creating, overwriting;
 
 	/*
 	 * search if variable with this name already exists
 	 */
-	for (nxt = env = environment.data; *env; env = nxt + 1) {
-		for (nxt = env; *nxt; ++nxt) {
-			if (nxt >= &environment.data[ENV_SIZE]) {
-				fprintf(stderr, "## Error: "
-					"environment not terminated\n");
-				errno = EINVAL;
-				return -1;
-			}
+	for (nxt = env = environment.data; env < end && *env; env = nxt + 1) {
+		nxt = fw_env_entry_end(env, end, "environment");
+		if (!nxt) {
+			errno = EINVAL;
+			return -1;
 		}
 		oldval = envmatch(name, env);
 		if (oldval)
 			break;
+	}
+	if (env >= end) {
+		fw_env_entry_end(env, end, "environment");
+		errno = EINVAL;
+		return -1;
 	}
 
 	deleting = (oldval && !(value && strlen(value)));
@@ -622,8 +718,11 @@ int fw_env_write(char *name, char *value)
 	/*
 	 * Append new definition at the end
 	 */
-	for (env = environment.data; *env || *(env + 1); ++env)
-		;
+	env = fw_env_data_end(environment.data, end, "environment");
+	if (!env) {
+		errno = EINVAL;
+		return -1;
+	}
 	if (env > environment.data)
 		++env;
 	/*
@@ -715,9 +814,14 @@ int fw_env_set(int argc, char *argv[], struct env_opts *opts)
 		value[len++] = '\0';
 	}
 
-	fw_env_write(name, value);
+	ret = fw_env_write(name, value);
 
 	free(value);
+
+	if (ret) {
+		fw_env_close(opts);
+		return ret;
+	}
 
 	ret = fw_env_flush(opts);
 	fw_env_close(opts);
@@ -1409,7 +1513,7 @@ static int flash_io(int mode, void *buf, size_t count)
 /*
  * Prevent confusion if running from erased flash memory
  */
-int fw_env_open(struct env_opts *opts)
+static int fw_env_open_selected(struct env_opts *opts, int use_fallback)
 {
 	int crc0, crc0_ok;
 	unsigned char flag0;
@@ -1445,6 +1549,13 @@ int fw_env_open(struct env_opts *opts)
 	if (!have_redund_env) {
 		struct env_image_single *single = buf0;
 
+		if (use_fallback) {
+			fprintf(stderr,
+				"## Error: fallback environment requested without redundant environment\n");
+			ret = -EINVAL;
+			goto open_cleanup;
+		}
+
 		crc0 = crc32(0, (uint8_t *)single->data, ENV_SIZE);
 		crc0_ok = (crc0 == single->crc);
 		if (!crc0_ok) {
@@ -1453,6 +1564,11 @@ int fw_env_open(struct env_opts *opts)
 			memcpy(single->data, default_environment,
 			       sizeof(default_environment));
 			environment.dirty = 1;
+		}
+		if (!fw_env_data_end(single->data, single->data + ENV_SIZE,
+				     "environment")) {
+			ret = -EINVAL;
+			goto open_cleanup;
 		}
 
 		environment.image = buf0;
@@ -1567,6 +1683,32 @@ int fw_env_open(struct env_opts *opts)
 		 * more, if we are writing, we will re-calculate CRC and update
 		 * flags before writing out
 		 */
+		if (use_fallback) {
+			dev_current = !dev_current;
+			if ((dev_current && !crc1_ok) ||
+			    (!dev_current && !crc0_ok)) {
+				fprintf(stderr,
+					"## Error: fallback environment has bad CRC\n");
+				ret = -EINVAL;
+				goto open_cleanup;
+			}
+		}
+		if (dev_current) {
+			if (!fw_env_data_end(redundant1->data,
+					     redundant1->data + ENV_SIZE,
+					     "environment")) {
+				ret = -EINVAL;
+				goto open_cleanup;
+			}
+		} else {
+			if (!fw_env_data_end(redundant0->data,
+					     redundant0->data + ENV_SIZE,
+					     "environment")) {
+				ret = -EINVAL;
+				goto open_cleanup;
+			}
+		}
+
 		if (dev_current) {
 			environment.image = buf1;
 			environment.crc = &redundant1->crc;
@@ -1591,6 +1733,11 @@ int fw_env_open(struct env_opts *opts)
 	free(buf1);
 
 	return ret;
+}
+
+int fw_env_open(struct env_opts *opts)
+{
+	return fw_env_open_selected(opts, 0);
 }
 
 /*

--- a/tools/env/fw_env_main.c
+++ b/tools/env/fw_env_main.c
@@ -49,10 +49,14 @@ static struct option long_options[] = {
 	{"noheader", no_argument, NULL, 'n'},
 	{"lock", required_argument, NULL, 'l'},
 	{"version", no_argument, NULL, 'v'},
+	{"used", no_argument, NULL, 'u'},
+	{"offset", no_argument, NULL, 'o'},
+	{"fallback", no_argument, NULL, 'f'},
 	{NULL, 0, NULL, 0}
 };
 
 static struct env_opts env_opts;
+static struct fw_printenv_opts printenv_opts;
 
 /* setenv options */
 static int noheader;
@@ -74,6 +78,9 @@ void usage_printenv(void)
 #endif
 		" -n, --noheader       do not repeat variable name in output\n"
 		" -l, --lock           lock node, default:/run\n"
+		" -u, --used           print used environment data bytes\n"
+		" -o, --offset         print selected environment offset\n"
+		" -f, --fallback       read the redundant fallback environment\n"
 		"\n");
 }
 
@@ -156,11 +163,20 @@ int parse_printenv_args(int argc, char *argv[])
 
 	parse_common_args(argc, argv);
 
-	while ((c = getopt_long(argc, argv, "a:c:ns:l:h:v", long_options, NULL))
+	while ((c = getopt_long(argc, argv, "a:c:ns:l:h:vuof", long_options, NULL))
 		!= EOF) {
 		switch (c) {
 		case 'n':
 			noheader = 1;
+			break;
+		case 'u':
+			printenv_opts.print_used = 1;
+			break;
+		case 'o':
+			printenv_opts.print_offset = 1;
+			break;
+		case 'f':
+			printenv_opts.use_fallback = 1;
 			break;
 		case 'a':
 		case 'c':
@@ -263,7 +279,8 @@ int main(int argc, char *argv[])
 	}
 
 	if (do_printenv) {
-		if (fw_printenv(argc, argv, noheader, &env_opts) != 0)
+		if (fw_printenv_ext(argc, argv, noheader, &env_opts,
+				    &printenv_opts) != 0)
 			retval = EXIT_FAILURE;
 	} else {
 		if (!script_file) {

--- a/tools/env/fw_env_private.h
+++ b/tools/env/fw_env_private.h
@@ -52,3 +52,14 @@
 	"ip=${ipaddr}:${serverip}:${gatewayip}:${netmask}:${hostname}::off; "\
 	"bootm"
 #endif
+
+struct env_opts;
+
+struct fw_printenv_opts {
+	int use_fallback;
+	int print_used;
+	int print_offset;
+};
+
+int fw_printenv_ext(int argc, char *argv[], int value_only,
+		    struct env_opts *opts, const struct fw_printenv_opts *print_opts);


### PR DESCRIPTION
## Summary
- preserve the Renos `fw_printenv` diagnostics options on the U-Boot 2025 envtools code path:
  - `-u` / `--used`: print used environment data bytes
  - `-o` / `--offset`: print the selected environment offset
  - `-f` / `--fallback`: inspect the redundant fallback environment
- keep the public `fw_env.h` API unchanged by routing the extra print-only state through a private envtools interface
- harden env parsing so CRC-valid but malformed environment blobs are rejected consistently before read/write operations
- keep offset diagnostics metadata-only, so `fw_printenv -f -o` can still locate a CRC-bad fallback page while normal reads and `-u` stay strict
- add a standalone file-backed regression test for active/fallback envs, reversed active selection, bad CRC fallback, malformed env tails, long options, invalid `-u -o` combinations, stdout plus exit-status assertions, and `fw_setenv` create/overwrite behavior

## Why
`retail-renos` bitflip diagnostics and repair tooling rely on the legacy Nedap `fw_printenv -u/-o/-f` behavior. This PR keeps that contract available when the OS later switches its fw-utils recipe to U-Boot 2025.

## Downstream retail-renos follow-up
This PR is only the `u-boot-at91` source-side enabler. It does not switch any OS image by itself.

When the `retail-renos` OS recipe is updated, the future 2025 `u-boot-fw-utils` recipe must point at the PR #20 merge commit on `u-boot-2025.07-mchp-renos`, or an exact pinned SHA that contains it. Do not copy the current downstream `u-boot-mchp_2025.07.bb` source pin blindly: that recipe still points at the older validation branch/SRCREV (`bart/renos-u-boot-2025.07-mchp-port` / `b2c9e7...`) and does not include this envtools compatibility work.

Expected downstream shape:
- add a dedicated `u-boot-fw-utils_2025.07...bb` that builds `envtools` from this branch/commit
- keep package/provider name `u-boot-fw-utils`
- keep installing `/sbin/fw_printenv`, `/sbin/fw_setenv`, and `/etc/fw_env.config`
- remove the old 2016-only fw-utils patch path (`0018-Add-size-and-offset-to-fw-printenv.patch`) from the 2025 tools recipe
- keep runtime scripts unchanged unless target validation proves otherwise

## Validation
- `git diff --check`
- `shellcheck test/env/test-fw-envtools.sh`
- `test/env/test-fw-envtools.sh`
- `test/env/test-fw-envtools.sh` from `/tmp` with a relative `OUT` path, verifying a newly-created caller-supplied output dir is cleaned
- `make O=/tmp/u-boot-at91-envtools-build nedap9g45_nandflash_defconfig && make O=/tmp/u-boot-at91-envtools-build -j$(nproc) envtools`
- `fw_printenv --help` from the built `envtools` binary shows `--used`, `--offset`, and `--fallback`
- `git diff -- tools/env/fw_env.c test/env/test-fw-envtools.sh | scripts/checkpatch.pl --no-tree --strict -`
- multi-agent pre-review and post-review; real findings were fixed in this PR, and the final two-lens post-review reported no findings

Not locally validated:
- full `nedap9g45_nandflash_defconfig` board build, because this laptop only has host `gcc` on PATH and fails on ARM `-march=armv5te`. The Yocto-packaged cross compiler found locally is not runnable from this checkout because its uninative interpreter path points at a missing `/data/.../ld-linux-x86-64.so.2`.
- target NAND/MTD behavior. That remains part of the downstream `retail-renos` recipe switch validation.

## Notes
No CI files are changed in this PR. The real production build gate remains the `retail-renos` GitHub Actions build once the recipe is switched to the merged branch/commit from this PR.