### PR TITLE
nedap9g45: emit the initrd ATAG on the legacy recovery bootm

### DIFF
--- a/configs/nedap9g45_nandflash_defconfig
+++ b/configs/nedap9g45_nandflash_defconfig
@@ -25,6 +25,7 @@ CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="ubi part rootfs && ubifsmount ubi0:nedap9g45-rootfs && ubifsload 72000000 /boot/uImage && setenv bootargs panic=1 quiet ${mtdparts} root=ubi0:nedap9g45-rootfs rw ubi.mtd=3,512 rootfstype=ubifs && bootm 72000000"
 CONFIG_SUPPORT_PASSING_ATAGS=y
 CONFIG_CMDLINE_TAG=y
+CONFIG_INITRD_TAG=y
 CONFIG_SYS_CBSIZE=2048
 CONFIG_SYS_PBSIZE=2083
 CONFIG_SYS_CONSOLE_IS_IN_ENV=y


### PR DESCRIPTION
## What

Add `CONFIG_INITRD_TAG=y` to `configs/nedap9g45_nandflash_defconfig`, next to the existing `CONFIG_SUPPORT_PASSING_ATAGS=y` / `CONFIG_CMDLINE_TAG=y`.

## Why

The OSMIGRATE recovery boots `bootm <kernel> <ramdisk>` with **no FDT** (`Working FDT set to 0`), so the recovery kernel must receive the external `uInitrd` via the `ATAG_INITRD2` ATAG. That ATAG is only emitted when `CONFIG_INITRD_TAG` is set (`BOOTM_ENABLE_INITRD_TAG` in `arch/arm/include/asm/bootm.h` → the `setup_initrd_tag()` call in `arch/arm/lib/bootm.c::boot_prep_linux`).

The defconfig had `SUPPORT_PASSING_ATAGS` and `CMDLINE_TAG` but **not** `INITRD_TAG`, so the built U-Boot set up the command-line ATAG (the kernel did receive `root=/dev/ram0 …`) but never the initrd ATAG. The recovery kernel then found no initramfs and panicked mounting an empty `/dev/ram0`:

```
## Loading init Ramdisk from Legacy Image at 74000000 ...
   Image Type:   ARM Linux RAMDisk Image (gzip compressed)
   Verifying Checksum ... OK
Working FDT set to 0
...
Kernel command line: ... root=/dev/ram0 rw rdinit=/init osmigrate.recovery=1 osmigrate.mode=factory-reflash ...
No filesystem could mount root, tried: ext3 ext2 ext4 vfat
Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(1,0)
```

The ramdisk is found and verified (`rd_start` is set), the cmdline ATAG works — only the initrd ATAG was missing. Keeping the symbol in the board defconfig (rather than an out-of-tree integration patch) makes it part of the board support so it cannot be silently dropped again.

## Validation

`make nedap9g45_nandflash_defconfig` on this branch yields, in the built `.config`:

```
CONFIG_SUPPORT_PASSING_ATAGS=y
CONFIG_CMDLINE_TAG=y
CONFIG_INITRD_TAG=y
```

The integration repo pins this commit and adds a build-the-config guard so the three ATAG symbols are asserted in the produced `.config` and this regression cannot ship green again.

One-line change; fast-forward on top of `u-boot-2025.07-mchp-renos`.